### PR TITLE
update glossary to use v2 structure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,2 @@
 source "https://rubygems.org"
-
-gem "geolexica-site", "1.7.0"
-gem "jekyll-geolexica"
+gem "geolexica-site", "~> 1.7.7"

--- a/_config.yaml
+++ b/_config.yaml
@@ -87,8 +87,9 @@ defaults:
       show_header_meta: true
 
 geolexica:
-  concepts_glob: "../isotc204-glossary/concepts/*.yaml"
-  glossary_path: "../isotc204-glossary"
+  glossary_path: "../isotc204-glossary/geolexica"
+  concepts_glob: "../isotc204-glossary/geolexica/concept/*.yaml"
+  localized_concepts_path: "../isotc204-glossary/geolexica/localized_concept"
   math: true
   term_languages:
     - eng


### PR DESCRIPTION
This PR contains the changes required in [isotc204.geolexica.org](https://github.com/geolexica/isotc204.geolexica.org) to update the glossary structure to V2.
Depends on https://github.com/geolexica/isotc204-glossary/pull/26