### PR TITLE
Add uriBase to site config

### DIFF
--- a/site-config.yml
+++ b/site-config.yml
@@ -1,5 +1,6 @@
 id: isotc204
 domain: isotc204.geolexica.org
+uriBase: https://isotc204.geolexica.org
 title: ISO/TC 204 ITS Vocabulary
 description: Authoritative vocabulary for intelligent transport systems from ISO 14812.
 


### PR DESCRIPTION
Sets uriBase: https://isotc204.geolexica.org for concept URI generation. Required by concept-browser v0.2.7+.