### PR TITLE
Update for concept-browser v0.2.9

### DIFF
--- a/about.md
+++ b/about.md
@@ -46,5 +46,4 @@ For questions about ISO/TC 204 ITS terminology:
 - **ISO 14812 Contact**: Kenneth Vaughn (kvaughn@trevilon.com)
 - **ISO/TC 204 Secretariat**: SAE International — [www.sae.org](http://www.sae.org/)
 - **ISO/TC 204 Technical Programme Manager**: Mr. Hakim Mkinsi (mkinsi@iso.org)
-- **ISO/TC 204 Secretariat**: info@enosema.org
 - **GitHub**: [github.com/geolexica/isotc204-glossary](https://github.com/geolexica/isotc204-glossary)

--- a/package.json
+++ b/package.json
@@ -1,10 +1,7 @@
 {
-  "version": "1.0.0",
-  "main": "babel.config.js",
-  "dependencies": {
-    "@babel/cli": "^7.5.5",
-    "@babel/core": "^7.5.5",
-    "@babel/polyfill": "^7.4.4",
-    "@babel/preset-env": "^7.5.5"
+  "private": true,
+  "description": "ISO/TC 204 ITS Vocabulary — deployment config for @glossarist/concept-browser",
+  "scripts": {
+    "build": "npx concept-browser build"
   }
 }

--- a/site-config.yml
+++ b/site-config.yml
@@ -1,5 +1,6 @@
 id: isotc204
 domain: isotc204.geolexica.org
+uriBase: https://isotc204.geolexica.org
 title: ISO/TC 204 ITS Vocabulary
 description: Authoritative vocabulary for intelligent transport systems from ISO 14812.
 

--- a/site-config.yml
+++ b/site-config.yml
@@ -87,5 +87,3 @@ defaults:
   language: eng
 
 copyright: "ISO/TC 204"
-
-email: info@enosema.org


### PR DESCRIPTION
Updates site config and package.json for the latest concept-browser release.

- Add `uriBase` field for config-driven URI generation
- Remove stale `email: info@enosema.org` from site config
- Replace stale babel dependencies in package.json with clean build script
- Builds will automatically use @glossarist/concept-browser@latest (v0.2.9)