### PR TITLE
feat: multi-edition lineage-series deployment (E1 + E2 + E3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install concept-browser
         run: npm install -g @glossarist/concept-browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
     },
     "../../glossarist/concept-browser": {
       "name": "@glossarist/concept-browser",
-      "version": "0.7.51",
+      "version": "0.7.61",
       "license": "MIT",
       "dependencies": {
         "@plurimath/plurimath": "^0.2.2",
@@ -19,7 +19,7 @@
         "autoprefixer": "^10.4.21",
         "d3": "^7.9.0",
         "favicons": "^7.2.0",
-        "glossarist": "^0.4.2",
+        "glossarist": "^0.4.10",
         "js-yaml": "^4.1.0",
         "jszip": "^3.10.1",
         "pinia": "^2.3.1",
@@ -107,7 +107,7 @@
         "d3": "^7.9.0",
         "fast-check": "^4.8.0",
         "favicons": "^7.2.0",
-        "glossarist": "^0.4.2",
+        "glossarist": "^0.4.10",
         "happy-dom": "^20.9.0",
         "js-yaml": "^4.1.0",
         "jszip": "^3.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,56 @@
   "packages": {
     "": {
       "dependencies": {
-        "@glossarist/concept-browser": "file:../../glossarist/glossarist-vocabulary-browser"
+        "@glossarist/concept-browser": "file:../../glossarist/concept-browser"
+      }
+    },
+    "../../glossarist/concept-browser": {
+      "name": "@glossarist/concept-browser",
+      "version": "0.7.51",
+      "license": "MIT",
+      "dependencies": {
+        "@plurimath/plurimath": "^0.2.2",
+        "@vitejs/plugin-vue": "^5.2.3",
+        "autoprefixer": "^10.4.21",
+        "d3": "^7.9.0",
+        "favicons": "^7.2.0",
+        "glossarist": "^0.4.2",
+        "js-yaml": "^4.1.0",
+        "jszip": "^3.10.1",
+        "pinia": "^2.3.1",
+        "postcss": "^8.5.3",
+        "sharp": "^0.34.5",
+        "tailwindcss": "^3.4.17",
+        "vite": "^6.3.5",
+        "vue": "^3.5.13",
+        "vue-router": "^4.5.1"
+      },
+      "bin": {
+        "concept-browser": "cli/index.mjs"
+      },
+      "devDependencies": {
+        "@rdfjs/dataset": "^2.0.2",
+        "@stryker-mutator/core": "^9.6.1",
+        "@stryker-mutator/vitest-runner": "^9.6.1",
+        "@types/d3": "^7.4.3",
+        "@types/n3": "^1.26.1",
+        "@vue/test-utils": "^2.4.8",
+        "fast-check": "^4.8.0",
+        "happy-dom": "^20.9.0",
+        "n3": "^1.26.0",
+        "rdf-validate-shacl": "^0.4.5",
+        "typescript": "~5.7.3",
+        "vitest": "^4.1.5",
+        "vue-tsc": "^2.2.8"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "../../glossarist/glossarist-vocabulary-browser": {
       "name": "@glossarist/concept-browser",
       "version": "0.3.7",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@plurimath/plurimath": "^0.2.2",
@@ -43,25 +87,35 @@
       }
     },
     "node_modules/@glossarist/concept-browser": {
-      "resolved": "../../glossarist/glossarist-vocabulary-browser",
+      "resolved": "../../glossarist/concept-browser",
       "link": true
     }
   },
   "dependencies": {
     "@glossarist/concept-browser": {
-      "version": "file:../../glossarist/glossarist-vocabulary-browser",
+      "version": "file:../../glossarist/concept-browser",
       "requires": {
         "@plurimath/plurimath": "^0.2.2",
+        "@rdfjs/dataset": "^2.0.2",
+        "@stryker-mutator/core": "^9.6.1",
+        "@stryker-mutator/vitest-runner": "^9.6.1",
         "@types/d3": "^7.4.3",
+        "@types/n3": "^1.26.1",
         "@vitejs/plugin-vue": "^5.2.3",
         "@vue/test-utils": "^2.4.8",
         "autoprefixer": "^10.4.21",
         "d3": "^7.9.0",
-        "glossarist": "file:../glossarist-js",
+        "fast-check": "^4.8.0",
+        "favicons": "^7.2.0",
+        "glossarist": "^0.4.2",
         "happy-dom": "^20.9.0",
         "js-yaml": "^4.1.0",
+        "jszip": "^3.10.1",
+        "n3": "^1.26.0",
         "pinia": "^2.3.1",
         "postcss": "^8.5.3",
+        "rdf-validate-shacl": "^0.4.5",
+        "sharp": "^0.34.5",
         "tailwindcss": "^3.4.17",
         "typescript": "~5.7.3",
         "vite": "^6.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
     },
     "../../glossarist/concept-browser": {
       "name": "@glossarist/concept-browser",
-      "version": "0.7.61",
+      "version": "0.7.66",
       "license": "MIT",
       "dependencies": {
         "@plurimath/plurimath": "^0.2.2",
@@ -19,7 +19,7 @@
         "autoprefixer": "^10.4.21",
         "d3": "^7.9.0",
         "favicons": "^7.2.0",
-        "glossarist": "^0.4.10",
+        "glossarist": "^0.4.12",
         "js-yaml": "^4.1.0",
         "jszip": "^3.10.1",
         "pinia": "^2.3.1",
@@ -107,7 +107,7 @@
         "d3": "^7.9.0",
         "fast-check": "^4.8.0",
         "favicons": "^7.2.0",
-        "glossarist": "^0.4.10",
+        "glossarist": "^0.4.12",
         "happy-dom": "^20.9.0",
         "js-yaml": "^4.1.0",
         "jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
     "build": "npx concept-browser build"
   },
   "dependencies": {
-    "@glossarist/concept-browser": "file:../../glossarist/glossarist-vocabulary-browser"
+    "@glossarist/concept-browser": "file:../../glossarist/concept-browser"
   }
 }

--- a/site-config.yml
+++ b/site-config.yml
@@ -4,14 +4,47 @@ uriBase: https://isotc204.geolexica.org
 title: ISO/TC 204 ITS Vocabulary
 description: Authoritative vocabulary for intelligent transport systems from ISO 14812.
 
+# Three editions as sibling datasets, wired into a lineage-series timeline.
+# The GCR packages are produced by isotc204-glossary's publish-gcr.yml
+# workflow on tag push. Each edition has its own per-edition GCR; the
+# `datasetGroups` block below tells concept-browser to render them as a
+# timeline (kind: lineage) — newest first.
 datasets:
-  - id: isotc204
-    uri: "urn:iso:std:iso:14812:*"
-    gcrPackage: https://github.com/geolexica/isotc204-glossary/releases/latest/download/isotc204-full.gcr
+  - id: isotc204-2022
+    uri: "urn:iso:std:iso:ts:14812:2022:*"
+    gcrPackage: https://github.com/geolexica/isotc204-glossary/releases/latest/download/isotc204-2022-full.gcr
     sourceRepo: https://github.com/geolexica/isotc204-glossary
-    title: "ISO/TC 204 ITS Vocabulary"
-    description: "Vocabulary for intelligent transport systems from ISO 14812"
+    title: "ISO/TC 204 ITS Vocabulary (2022, Edition 1)"
+    description: "Edition 1, originally published as ISO/TS 14812:2022"
     owner: ISO/TC 204
+    color: "#d97706"
+
+  - id: isotc204-2025
+    uri: "urn:iso:std:iso:14812:2025:*"
+    gcrPackage: https://github.com/geolexica/isotc204-glossary/releases/latest/download/isotc204-2025-full.gcr
+    sourceRepo: https://github.com/geolexica/isotc204-glossary
+    title: "ISO/TC 204 ITS Vocabulary (2025, Edition 2)"
+    description: "Edition 2, published as ISO 14812:2025"
+    owner: ISO/TC 204
+    color: "#92400e"
+
+  - id: isotc204-ed3
+    uri: "urn:iso:std:iso:14812:ed3:*"
+    gcrPackage: https://github.com/geolexica/isotc204-glossary/releases/latest/download/isotc204-ed3-full.gcr
+    sourceRepo: https://github.com/geolexica/isotc204-glossary
+    title: "ISO/TC 204 ITS Vocabulary (Edition 3, draft)"
+    description: "Edition 3 draft, generated from the iso14812 ontology"
+    owner: ISO/TC 204
+    color: "#451a03"
+
+datasetGroups:
+  - id: isotc204
+    label: ISO/TC 204 ITS Vocabulary
+    kind: lineage
+    datasets:
+      - isotc204-ed3
+      - isotc204-2025
+      - isotc204-2022
     color: "#d97706"
 
 routing:

--- a/site-config.yml
+++ b/site-config.yml
@@ -17,7 +17,9 @@ datasets:
     title: "ISO/TC 204 ITS Vocabulary (2022, Edition 1)"
     description: "Edition 1, originally published as ISO/TS 14812:2022"
     owner: ISO/TC 204
-    color: "#d97706"
+    color:
+      light: "#f59e0b"
+      dark: "#fbbf24"
 
   - id: isotc204-2025
     uri: "urn:iso:std:iso:14812:2025:*"
@@ -26,7 +28,9 @@ datasets:
     title: "ISO/TC 204 ITS Vocabulary (2025, Edition 2)"
     description: "Edition 2, published as ISO 14812:2025"
     owner: ISO/TC 204
-    color: "#92400e"
+    color:
+      light: "#d97706"
+      dark: "#f59e0b"
 
   - id: isotc204-ed3
     uri: "urn:iso:std:iso:14812:ed3:*"
@@ -35,17 +39,26 @@ datasets:
     title: "ISO/TC 204 ITS Vocabulary (Edition 3, draft)"
     description: "Edition 3 draft, generated from the iso14812 ontology"
     owner: ISO/TC 204
-    color: "#451a03"
+    color:
+      light: "#b45309"
+      dark: "#d97706"
 
 datasetGroups:
   - id: isotc204
     label: ISO/TC 204 ITS Vocabulary
     kind: lineage
+    current: isotc204-ed3
+    description: >-
+      ISO/TC 204 Intelligent Transport Systems vocabulary across three
+      editions. Edition 3 is the current working draft; Editions 1 and 2
+                      are the published predecessors, kept for cross-edition navigation.
     datasets:
       - isotc204-ed3
       - isotc204-2025
       - isotc204-2022
-    color: "#d97706"
+    color:
+      light: "#d97706"
+      dark: "#f59e0b"
 
 routing:
   - uri: "urn:iec:std:iec:60050:*"

--- a/site-content/groups/isotc204/about/about.eng.md
+++ b/site-content/groups/isotc204/about/about.eng.md
@@ -1,0 +1,37 @@
+# ISO/TC 204 ITS Vocabulary — Lineage Series
+
+This group compiles three editions of the **ISO 14812 — Intelligent Transport
+Systems — Vocabulary** standard, maintained by ISO/TC 204.
+
+## Editions in this series
+
+| Edition | Publication | Status | Concepts |
+|---------|-------------|--------|----------|
+| Edition 1 | ISO/TS 14812:2022 | Superseded | 319 |
+| Edition 2 | ISO 14812:2025 | Superseded | 313 |
+| Edition 3 (draft) | In progress | Current working draft | 383 |
+
+Each edition supersedes its predecessor; the concept-browser derives
+`superseded_by` edges at render time from the authored forward `supersedes`
+relationships. Concepts that existed in earlier editions but were withdrawn
+in later ones are flagged accordingly.
+
+## Source
+
+All three datasets are generated and maintained in the
+[geolexica/isotc204-glossary](https://github.com/geolexica/isotc204-glossary)
+repository.
+
+- Edition 1 was originally imported from the ISO/TC 204 Multi-Lingual
+  Glossary of Terms spreadsheet.
+- Edition 2 is converted from the Enterprise Architect XMI export of the
+  ISO/TC 204 vocabulary model.
+- Edition 3 is converted from the markdown term files and Turtle ontology
+  in the [ISO-TC204/iso14812](https://github.com/ISO-TC204/iso14812)
+  repository.
+
+## About ISO/TC 204
+
+ISO/TC 204 is the technical committee responsible for Intelligent Transport
+Systems standardization within ISO. Visit the committee page at
+[ISO/TC 204](https://committee.iso.org/home/tc204) for more information.


### PR DESCRIPTION
feat: multi-edition lineage-series deployment (E1 + E2 + E3)

Restructures site-config.yml for the multi-edition dataset that landed
in geolexica/isotc204-glossary (PR #33, merged).

Three editions configured as sibling datasets with a `kind: lineage`
dataset group, so concept-browser renders the edition timeline UI:

- isotc204-2022: urn:iso:std:iso:ts:14812:2022, E1 (319 concepts)
- isotc204-2025: urn:iso:std:iso:14812:2025,    E2 (313 concepts)
- isotc204-ed3:  urn:iso:std:iso:14812:ed3,      E3 draft (383 concepts)

Cross-edition `supersedes` edges (611 total) wire concepts into a
navigable timeline; concept-browser derives `superseded_by` at render.

Each edition points at its own per-edition GCR package produced by
isotc204-glossary's publish-gcr.yml workflow.

Also picks up the package-lock.json fix from this branch (resolves the
stale @glossarist/concept-browser symlink that pointed at the old
glossarist-vocabulary-browser path).

## Local verification

Built locally with `localPath:` substitutes for the GCR URLs — all
three editions processed correctly:

- 319 + 313 + 383 concepts across three datasets
- Per-dataset manifest.json + index.json + concepts/*.json emitted
- cross-ref-index.json + versions.ttl produced
- E3 manifest shows `editionStatus: "current"` (newest in the lineage)
- SPA bundled and 404.html generated for SPA fallback

## Blocker before merge / deploy

The new per-edition GCR URLs (`isotc204-2022-full.gcr`,
`isotc204-2025-full.gcr`, `isotc204-ed3-full.gcr`) do not exist in the
latest release yet — they only get published when a new tag is pushed
on isotc204-glossary (which now has the per-edition packaging workflow
from PR #33). Once that tag is cut, the URLs resolve and the deployment
works end-to-end.

Until then, the live deployment stays on the existing v1.1.0 GCR.
This PR is safe to merge ahead of the tag — the config will simply
404 on the GCR fetch until the tag exists.

## Test plan

- [x] `npm install` resolves the new concept-browser path
- [x] `SITE_CONFIG=verify.yml npx concept-browser build` succeeds with
      local-path substitutes for all three editions
- [x] dist/data/{isotc204-2022,isotc204-2025,isotc204-ed3}/ all populated
- [x] dist/data/datasets.json lists all three datasets
- [x] dist/data/isotc204-ed3/manifest.json reports `editionStatus: current`
- [ ] After new isotc204-glossary tag: `npx concept-browser build` succeeds
      against the production GCR URLs (without local-path substitutes)
